### PR TITLE
Run rustfmt and fix some Clippy warnings

### DIFF
--- a/src/elevio/elev.rs
+++ b/src/elevio/elev.rs
@@ -1,69 +1,62 @@
 #![allow(dead_code)]
 
-use std::net::TcpStream;
-use std::sync::*;
 use std::fmt;
 use std::io::*;
-
-
+use std::net::TcpStream;
+use std::sync::*;
 
 #[derive(Clone, Debug)]
 pub struct Elevator {
-        socket:     Arc<Mutex<TcpStream>>,
+    socket: Arc<Mutex<TcpStream>>,
     pub num_floors: u8,
 }
 
+pub const HALL_UP: u8 = 0;
+pub const HALL_DOWN: u8 = 1;
+pub const CAB: u8 = 2;
 
-pub const HALL_UP:      u8 = 0;
-pub const HALL_DOWN:    u8 = 1;
-pub const CAB:          u8 = 2;
-
-pub const DIRN_DOWN:    u8 = u8::MAX;
-pub const DIRN_STOP:    u8 = 0;
-pub const DIRN_UP:      u8 = 1;
+pub const DIRN_DOWN: u8 = u8::MAX;
+pub const DIRN_STOP: u8 = 0;
+pub const DIRN_UP: u8 = 1;
 
 impl Elevator {
-
     pub fn init(addr: &str, num_floors: u8) -> Result<Elevator> {
         Ok(Self {
-            socket: Arc::new(Mutex::new( TcpStream::connect(addr)? )),
+            socket: Arc::new(Mutex::new(TcpStream::connect(addr)?)),
             num_floors: num_floors,
         })
     }
-    
-    
-    pub fn motor_direction(&self, dirn: u8){
+
+    pub fn motor_direction(&self, dirn: u8) {
         let buf = [1, dirn, 0, 0];
         let mut sock = self.socket.lock().unwrap();
         sock.write(&buf).unwrap();
     }
-    
-    pub fn call_button_light(&self, floor: u8, call: u8, on: bool){
+
+    pub fn call_button_light(&self, floor: u8, call: u8, on: bool) {
         let buf = [2, call, floor, on as u8];
         let mut sock = self.socket.lock().unwrap();
         sock.write(&buf).unwrap();
     }
-    
-    pub fn floor_indicator(&self, floor: u8){
+
+    pub fn floor_indicator(&self, floor: u8) {
         let buf = [3, floor, 0, 0];
         let mut sock = self.socket.lock().unwrap();
         sock.write(&buf).unwrap();
     }
-    
-    pub fn door_light(&self, on: bool){
+
+    pub fn door_light(&self, on: bool) {
         let buf = [4, on as u8, 0, 0];
         let mut sock = self.socket.lock().unwrap();
         sock.write(&buf).unwrap();
     }
-    
-    pub fn stop_button_light(&self, on: bool){
+
+    pub fn stop_button_light(&self, on: bool) {
         let buf = [5, on as u8, 0, 0];
         let mut sock = self.socket.lock().unwrap();
         sock.write(&buf).unwrap();
     }
-    
-    
-    
+
     pub fn call_button(&self, floor: u8, call: u8) -> bool {
         let mut buf = [6, call, floor, 0];
         let mut sock = self.socket.lock().unwrap();
@@ -71,7 +64,7 @@ impl Elevator {
         sock.read(&mut buf).unwrap();
         return buf[1] != 0;
     }
-    
+
     pub fn floor_sensor(&self) -> Option<u8> {
         let mut buf = [7, 0, 0, 0];
         let mut sock = self.socket.lock().unwrap();
@@ -83,7 +76,7 @@ impl Elevator {
             None
         }
     }
-    
+
     pub fn stop_button(&self) -> bool {
         let mut buf = [8, 0, 0, 0];
         let mut sock = self.socket.lock().unwrap();
@@ -91,7 +84,7 @@ impl Elevator {
         sock.read(&mut buf).unwrap();
         return buf[1] != 0;
     }
-    
+
     pub fn obstruction(&self) -> bool {
         let mut buf = [9, 0, 0, 0];
         let mut sock = self.socket.lock().unwrap();
@@ -101,19 +94,9 @@ impl Elevator {
     }
 }
 
-
 impl fmt::Display for Elevator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let addr = self.socket.lock().unwrap().peer_addr().unwrap();
         write!(f, "Elevator@{}({})", addr, self.num_floors)
     }
 }
-
-
-
-
-
-
-
-
-

--- a/src/elevio/elev.rs
+++ b/src/elevio/elev.rs
@@ -23,7 +23,7 @@ impl Elevator {
     pub fn init(addr: &str, num_floors: u8) -> Result<Elevator> {
         Ok(Self {
             socket: Arc::new(Mutex::new(TcpStream::connect(addr)?)),
-            num_floors: num_floors,
+            num_floors,
         })
     }
 
@@ -62,13 +62,13 @@ impl Elevator {
         let mut sock = self.socket.lock().unwrap();
         sock.write(&mut buf).unwrap();
         sock.read(&mut buf).unwrap();
-        return buf[1] != 0;
+        buf[1] != 0
     }
 
     pub fn floor_sensor(&self) -> Option<u8> {
         let mut buf = [7, 0, 0, 0];
         let mut sock = self.socket.lock().unwrap();
-        sock.write(&mut buf).unwrap();
+        sock.write(&buf).unwrap();
         sock.read(&mut buf).unwrap();
         if buf[1] != 0 {
             Some(buf[2])
@@ -80,17 +80,17 @@ impl Elevator {
     pub fn stop_button(&self) -> bool {
         let mut buf = [8, 0, 0, 0];
         let mut sock = self.socket.lock().unwrap();
-        sock.write(&mut buf).unwrap();
+        sock.write(&buf).unwrap();
         sock.read(&mut buf).unwrap();
-        return buf[1] != 0;
+        buf[1] != 0
     }
 
     pub fn obstruction(&self) -> bool {
         let mut buf = [9, 0, 0, 0];
         let mut sock = self.socket.lock().unwrap();
-        sock.write(&mut buf).unwrap();
+        sock.write(&buf).unwrap();
         sock.read(&mut buf).unwrap();
-        return buf[1] != 0;
+        buf[1] != 0
     }
 }
 

--- a/src/elevio/poll.rs
+++ b/src/elevio/poll.rs
@@ -1,26 +1,23 @@
-
-
-use std::time;
-use std::thread;
 use crossbeam_channel as cbc;
+use std::thread;
+use std::time;
 
 use super::elev;
 
 #[derive(Debug)]
 pub struct CallButton {
-    pub floor:  u8,
-    pub call:   u8,
+    pub floor: u8,
+    pub call: u8,
 }
 
-pub fn call_buttons(elev: elev::Elevator, ch: cbc::Sender<CallButton>, period: time::Duration){
-
+pub fn call_buttons(elev: elev::Elevator, ch: cbc::Sender<CallButton>, period: time::Duration) {
     let mut prev = vec![[false; 3]; elev.num_floors.into()];
     loop {
         for f in 0..elev.num_floors {
             for c in 0..3 {
                 let v = elev.call_button(f, c);
-                if v  &&  prev[f as usize][c as usize] != v {
-                    ch.send(CallButton{floor: f, call: c}).unwrap();
+                if v && prev[f as usize][c as usize] != v {
+                    ch.send(CallButton { floor: f, call: c }).unwrap();
                 }
                 prev[f as usize][c as usize] = v;
             }
@@ -29,24 +26,23 @@ pub fn call_buttons(elev: elev::Elevator, ch: cbc::Sender<CallButton>, period: t
     }
 }
 
-pub fn floor_sensor(elev: elev::Elevator, ch: cbc::Sender<u8>, period: time::Duration){
-    
+pub fn floor_sensor(elev: elev::Elevator, ch: cbc::Sender<u8>, period: time::Duration) {
     let mut prev = u8::MAX;
     loop {
         match elev.floor_sensor() {
-            Some(f) => 
+            Some(f) => {
                 if f != prev {
                     ch.send(f).unwrap();
                     prev = f;
-                },
+                }
+            }
             None => (),
         }
         thread::sleep(period)
     }
 }
 
-pub fn stop_button(elev: elev::Elevator, ch: cbc::Sender<bool>, period: time::Duration){
-    
+pub fn stop_button(elev: elev::Elevator, ch: cbc::Sender<bool>, period: time::Duration) {
     let mut prev = false;
     loop {
         let v = elev.stop_button();
@@ -58,8 +54,7 @@ pub fn stop_button(elev: elev::Elevator, ch: cbc::Sender<bool>, period: time::Du
     }
 }
 
-pub fn obstruction(elev: elev::Elevator, ch: cbc::Sender<bool>, period: time::Duration){
-    
+pub fn obstruction(elev: elev::Elevator, ch: cbc::Sender<bool>, period: time::Duration) {
     let mut prev = false;
     loop {
         let v = elev.obstruction();

--- a/src/elevio/poll.rs
+++ b/src/elevio/poll.rs
@@ -29,14 +29,11 @@ pub fn call_buttons(elev: elev::Elevator, ch: cbc::Sender<CallButton>, period: t
 pub fn floor_sensor(elev: elev::Elevator, ch: cbc::Sender<u8>, period: time::Duration) {
     let mut prev = u8::MAX;
     loop {
-        match elev.floor_sensor() {
-            Some(f) => {
-                if f != prev {
-                    ch.send(f).unwrap();
-                    prev = f;
-                }
+        if let Some(f) = elev.floor_sensor() {
+            if f != prev {
+                ch.send(f).unwrap();
+                prev = f;
             }
-            None => (),
         }
         thread::sleep(period)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-
 use std::thread::*;
 use std::time::*;
 
@@ -11,52 +10,41 @@ mod elevio {
 use elevio::elev as e;
 
 fn main() -> std::io::Result<()> {
-    
     let elev_num_floors = 4;
     let elevator = e::Elevator::init("localhost:15657", elev_num_floors)?;
-    println!("Elevator started:\n{:#?}", elevator);    
+    println!("Elevator started:\n{:#?}", elevator);
 
-    
     let poll_period = Duration::from_millis(25);
-    
+
     let (call_button_tx, call_button_rx) = cbc::unbounded::<elevio::poll::CallButton>();
     {
         let elevator = elevator.clone();
-        spawn(move ||{
-            elevio::poll::call_buttons(elevator, call_button_tx, poll_period) 
-        });
+        spawn(move || elevio::poll::call_buttons(elevator, call_button_tx, poll_period));
     }
-    
-    let (floor_sensor_tx, floor_sensor_rx) = cbc::unbounded::<u8>();    
+
+    let (floor_sensor_tx, floor_sensor_rx) = cbc::unbounded::<u8>();
     {
         let elevator = elevator.clone();
-        spawn(move ||{
-            elevio::poll::floor_sensor(elevator, floor_sensor_tx, poll_period)
-        });
+        spawn(move || elevio::poll::floor_sensor(elevator, floor_sensor_tx, poll_period));
     }
-    
-    let (stop_button_tx, stop_button_rx) = cbc::unbounded::<bool>();    
+
+    let (stop_button_tx, stop_button_rx) = cbc::unbounded::<bool>();
     {
         let elevator = elevator.clone();
-        spawn(move ||{
-            elevio::poll::stop_button(elevator, stop_button_tx, poll_period)
-        });
+        spawn(move || elevio::poll::stop_button(elevator, stop_button_tx, poll_period));
     }
-    
-    let (obstruction_tx, obstruction_rx) = cbc::unbounded::<bool>();    
+
+    let (obstruction_tx, obstruction_rx) = cbc::unbounded::<bool>();
     {
         let elevator = elevator.clone();
-        spawn(move ||{
-            elevio::poll::obstruction(elevator, obstruction_tx, poll_period)
-        });
+        spawn(move || elevio::poll::obstruction(elevator, obstruction_tx, poll_period));
     }
-    
-    
+
     let mut dirn = e::DIRN_DOWN;
     if elevator.floor_sensor().is_none() {
         elevator.motor_direction(dirn);
     }
-    
+
     loop {
         cbc::select! {
             recv(call_button_rx) -> a => {
@@ -67,7 +55,7 @@ fn main() -> std::io::Result<()> {
             recv(floor_sensor_rx) -> a => {
                 let floor = a.unwrap();
                 println!("Floor: {:#?}", floor);
-                dirn = 
+                dirn =
                     if floor == 0 {
                         e::DIRN_UP
                     } else if floor == elev_num_floors-1 {


### PR DESCRIPTION
- Run rustfmt
- Fix some clippy warnings

There is one clippy warning left, [unused_io_amount](https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount), since `ìo::Read` isn't guaranteed to read the entire buffer it is reading.
In this case I think it is safe to just use `ìo::Read_exact`, as long as we aren't expecting to receive shorter messages than the bufer we are trying to fill.

